### PR TITLE
fix order of City CSV columns in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ip_range_start, ip_range_end, country_code
 ### City
 
 ```CSV
-ip_range_start, ip_range_end, country_code, city, state1, state2, postcode, latitude, longitude, timezone
+ip_range_start, ip_range_end, country_code, state1, state2, city, postcode, latitude, longitude, timezone
 ```
 
 | Database | Type | License | Updated | IPv4 | IPv6 | IPv4+IPV6 | IPv4-num | IPv6-num |


### PR DESCRIPTION
This PR fixes a minor documentation issue, where the CSV columns of the City data model were not in the correct order in the README.

Example row from `geolite2-city-ipv4-num.csv`
```
28444672,28444927,US,Ohio,,Columbus,43215,39.9625,-83.0061,America/New_York
```

And from `dbip-city-ipv4.csv`
```
1.0.0.0,1.0.0.255,AU,Queensland,,South Brisbane,,-27.4767,153.017,
```

Note how city should be Columbus, and South Brisbane, instead of Ohio and Queensland, respectively.