### PR TITLE
fix: sanitize shell/subprocess call in create-mmdb.js

### DIFF
--- a/tools/old/create-mmdb.js
+++ b/tools/old/create-mmdb.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const execSync = require('child_process').execSync
+const {execSync, execFileSync} = require('child_process')
 const isWin = process.platform === 'win32'
 const topDir = path.resolve(__dirname, '..')
 const mmdbCmd = path.join(topDir, 'ip-location-to-mmdb-' + (isWin ? 'windows-x64.exe' : 'linux-x64.bin'))
@@ -26,13 +26,13 @@ var run = function(){
 			try{
 				if(dir.includes('-city')){
 					// uncompress .csv.gz files
-					execSync('7z e -aoa -bd -bso0 -bsp0 -o' + path.join(topDir, nonMmdbDir) + ' ' + inputV4 + '.gz')
-					execSync('7z e -aoa -bd -bso0 -bsp0 -o' + path.join(topDir, nonMmdbDir) + ' ' + inputV6 + '.gz')
+					execFileSync('7z', ['e', '-aoa', '-bd', '-bso0', '-bsp0', '-o' + path.join(topDir, nonMmdbDir), inputV4 + '.gz'])
+					execFileSync('7z', ['e', '-aoa', '-bd', '-bso0', '-bsp0', '-o' + path.join(topDir, nonMmdbDir), inputV6 + '.gz'])
 				} else {
-					execSync(mmdbCmd + ' -i ' + inputV4 + ' -i ' + inputV6 + ' -o ' + outputV46 + ' -r ' + recordSize)
+					execFileSync(mmdbCmd, ['-i', inputV4, '-i', inputV6, '-o', outputV46, '-r', recordSize])
 				}
-				execSync(mmdbCmd + ' -i ' + inputV4 + ' -o ' + outputV4 + ' -r ' + (dir.includes('dbip-city') ? 28 : recordSize))
-				execSync(mmdbCmd + ' -i ' + inputV6 + ' -o ' + outputV6 + ' -r ' + recordSize)
+				execFileSync(mmdbCmd, ['-i', inputV4, '-o', outputV4, '-r', (dir.includes('dbip-city') ? 28 : recordSize)])
+				execFileSync(mmdbCmd, ['-i', inputV6, '-o', outputV6, '-r', recordSize])
 				if(dir.includes('-city')){
 					fs.unlinkSync(path.join(topDir, nonMmdbDir, nonMmdbDir + '-ipv4.csv'))
 					fs.unlinkSync(path.join(topDir, nonMmdbDir, nonMmdbDir + '-ipv6.csv'))


### PR DESCRIPTION
## Summary
Fix high severity security issue in `tools/old/create-mmdb.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tools/old/create-mmdb.js:1` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-78 |

**Description**: The create-mmdb.js script uses execSync() with string concatenation to construct shell commands. Directory names read from the filesystem are incorporated directly into shell commands via string concatenation. An attacker who can create directories with shell metacharacters in the repository could trigger command injection when the script processes these directories. The script uses execSync with a shell string rather than the safer array form, making it vulnerable to shell metacharacter interpretation.

## Evidence

**Exploitation scenario**: An attacker creates a directory in the repository with a name containing shell metacharacters, such as 'test-mmdb$(whoami)' or 'test-mmdb; touch /tmp/pwned'.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Changes
- `tools/old/create-mmdb.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
